### PR TITLE
feat: AI生成コンテンツの日本語化

### DIFF
--- a/scripts/modules/task-manager/analyze-task-complexity.js
+++ b/scripts/modules/task-manager/analyze-task-complexity.js
@@ -340,7 +340,7 @@ async function analyzeTaskComplexity(options, context = {}) {
 		// Continue with regular analysis path
 		const prompt = generateInternalComplexityAnalysisPrompt(tasksData);
 		const systemPrompt =
-			'You are an expert software architect and project manager analyzing task complexity. Respond only with the requested valid JSON array.';
+			'You are an expert software architect and project manager analyzing task complexity. 全ての分析結果の内容（taskTitle, expansionPrompt, reasoning）は日本語で記述してください。ただし、JSONのキー名は英語のままにしてください。Respond only with the requested valid JSON array.';
 
 		let loadingIndicator = null;
 		if (outputFormat === 'text') {

--- a/scripts/modules/task-manager/expand-task.js
+++ b/scripts/modules/task-manager/expand-task.js
@@ -58,6 +58,8 @@ function generateMainSystemPrompt(subtaskCount) {
 	return `You are an AI assistant helping with task breakdown for software development.
 You need to break down a high-level task into ${subtaskCount} specific subtasks that can be implemented one by one.
 
+全てのサブタスクの内容（title, description, details, testStrategy）は日本語で記述してください。ただし、JSONのキー名とステータス値（pending等）は英語のままにしてください。
+
 Subtasks should:
 1. Be specific and actionable implementation steps
 2. Follow a logical sequence
@@ -531,7 +533,7 @@ async function expandTask(
 			promptContent += `${complexityReasoningContext}`.trim();
 
 			// --- Use Simplified System Prompt for Report Prompts ---
-			systemPrompt = `You are an AI assistant helping with task breakdown. Generate exactly ${finalSubtaskCount} subtasks based on the provided prompt and context. Respond ONLY with a valid JSON object containing a single key "subtasks" whose value is an array of the generated subtask objects. Each subtask object in the array must have keys: "id", "title", "description", "dependencies", "details", "status". Ensure the 'id' starts from ${nextSubtaskId} and is sequential. Ensure 'dependencies' only reference valid prior subtask IDs generated in this response (starting from ${nextSubtaskId}). Ensure 'status' is 'pending'. Do not include any other text or explanation.`;
+			systemPrompt = `You are an AI assistant helping with task breakdown. Generate exactly ${finalSubtaskCount} subtasks based on the provided prompt and context. 全てのサブタスクの内容（title, description, details, testStrategy）は日本語で記述してください。ただし、JSONのキー名とステータス値（pending等）は英語のままにしてください。Respond ONLY with a valid JSON object containing a single key "subtasks" whose value is an array of the generated subtask objects. Each subtask object in the array must have keys: "id", "title", "description", "dependencies", "details", "status". Ensure the 'id' starts from ${nextSubtaskId} and is sequential. Ensure 'dependencies' only reference valid prior subtask IDs generated in this response (starting from ${nextSubtaskId}). Ensure 'status' is 'pending'. Do not include any other text or explanation.`;
 			logger.info(
 				`Using expansion prompt from complexity report and simplified system prompt for task ${task.id}.`
 			);
@@ -548,7 +550,7 @@ async function expandTask(
 					nextSubtaskId
 				);
 				// Use the specific research system prompt if needed, or a standard one
-				systemPrompt = `You are an AI assistant that responds ONLY with valid JSON objects as requested. The object should contain a 'subtasks' array.`; // Or keep generateResearchSystemPrompt if it exists
+				systemPrompt = `You are an AI assistant that responds ONLY with valid JSON objects as requested. The object should contain a 'subtasks' array. 全てのサブタスクの内容（title, description, details, testStrategy）は日本語で記述してください。ただし、JSONのキー名とステータス値（pending等）は英語のままにしてください。`; // Or keep generateResearchSystemPrompt if it exists
 			} else {
 				promptContent = generateMainUserPrompt(
 					task,

--- a/scripts/modules/task-manager/parse-prd.js
+++ b/scripts/modules/task-manager/parse-prd.js
@@ -168,6 +168,8 @@ Your task breakdown should incorporate this research, resulting in more detailed
 		// Base system prompt for PRD parsing
 		const systemPrompt = `You are an AI assistant specialized in analyzing Product Requirements Documents (PRDs) and generating a structured, logically ordered, dependency-aware and sequenced list of development tasks in JSON format.${researchPromptAddition}
 
+全てのタスクの内容（title, description, details, testStrategy）は日本語で記述してください。ただし、JSONのキー名とステータス値（pending等）は英語のままにしてください。
+
 Analyze the provided PRD content and generate approximately ${numTasks} top-level development tasks. If the complexity or the level of detail of the PRD is high, generate more tasks relative to the complexity of the PRD
 Each task should represent a logical unit of work needed to implement the requirements and focus on the most direct and effective way to implement the requirements without unnecessary complexity or overengineering. Include pseudo-code, implementation details, and test strategy for each task. Find the most up to date information to implement each task.
 Assign sequential IDs starting from ${nextId}. Infer title, description, details, and test strategy for each task based *only* on the PRD content.


### PR DESCRIPTION
## 概要

Task Master APIのAI生成コンテンツを日本語で出力するようにシステムプロンプトを修正しました。

Closes #9

## 変更内容

以下の3つのファイルでシステムプロンプトを修正：

- `parse-prd.js`: PRD解析時のタスク生成
- `expand-task.js`: タスク展開時のサブタスク生成（3箇所）
- `analyze-task-complexity.js`: タスク複雑度分析

## 影響範囲

- APIレスポンスのタスク内容（title, description, details, testStrategy等）が日本語で返されるようになります
- JSONのキー名とステータス値（pending等）は英語のまま維持されます

## テスト

既存の機能に対するプロンプトの追加のみで、新たなテストは不要です。

Generated with [Claude Code](https://claude.ai/code)