### PR TITLE
fix: タスクAPIレスポンスでdependenciesを単純な配列に変換

### DIFF
--- a/api/routes/tasks-db.js
+++ b/api/routes/tasks-db.js
@@ -114,11 +114,17 @@ router.get('/', authMiddleware, async (req, res) => {
 		if (status) filteredBy.status = status;
 		if (assignee) filteredBy.assignee = assignee;
 
+		// Transform dependencies to simple array
+		const transformedTasks = tasks.map(task => ({
+			...task,
+			dependencies: task.dependencies?.map(dep => dep.depends_on_task_id) || []
+		}));
+
 		res.json({
 			success: true,
 			data: {
-				tasks,
-				totalTasks: tasks.length,
+				tasks: transformedTasks,
+				totalTasks: transformedTasks.length,
 				filteredBy: Object.keys(filteredBy).length > 0 ? filteredBy : 'all'
 			}
 		});
@@ -204,9 +210,15 @@ router.get('/:id', authMiddleware, async (req, res) => {
 			});
 		}
 
+		// Transform dependencies to simple array
+		const transformedTask = {
+			...task,
+			dependencies: task.dependencies?.map(dep => dep.depends_on_task_id) || []
+		};
+
 		res.json({
 			success: true,
-			data: task
+			data: transformedTask
 		});
 	} catch (error) {
 		console.error('Error fetching task:', error);


### PR DESCRIPTION
## 問題
- task_dependencies テーブルから取得した依存関係が {depends_on_task_id} オブジェクトの配列として返されていた
- フロントエンドの TaskDetailSidebar が単純な数値の配列を期待していたため、Reactレンダリングエラーが発生

## 修正内容
- GET /api/v1/tasks: 全タスク取得時にdependenciesを数値配列に変換
- GET /api/v1/tasks/:id: 単一タスク取得時も同様に変換
- 変換処理: task.dependencies?.map(dep => dep.depends_on_task_id) || []

## 結果
- "Objects are not valid as a React child" エラーが解消
- フロントエンドで依存関係が正しく表示されるように

🤖 Generated with [Claude Code](https://claude.ai/code)