### PR TITLE
fix: タスク更新時の未定義変数エラーを修正

### DIFF
--- a/api/db/helpers.js
+++ b/api/db/helpers.js
@@ -226,9 +226,9 @@ export async function updateTask(taskId, updates) {
 	const { dependencies, subtasks, ...taskUpdates } = updates;
 
 	// Convert camelCase to snake_case for database
-	if (task.testStrategy !== undefined) {
-		task.test_strategy = task.testStrategy;
-		delete task.testStrategy;
+	if (taskUpdates.testStrategy !== undefined) {
+		taskUpdates.test_strategy = taskUpdates.testStrategy;
+		delete taskUpdates.testStrategy;
 	}
 
 	// Update the task


### PR DESCRIPTION
updateTask関数内で誤って未定義の`task`変数を参照していた問題を修正しました。

## 修正内容
- `api/db/helpers.js`の229-232行目で`task`を`taskUpdates`に変更
- camelCase形式の`testStrategy`をsnake_case形式の`test_strategy`に変換する処理が正しく動作するように修正

## 問題の詳細
PUT /api/v1/tasks/:id エンドポイントを呼び出した際に「task is not defined」エラーが発生していました。 これは、関数内で分割代入によって作成された`taskUpdates`変数を使用すべき箇所で、存在しない`task`変数を参照していたことが原因でした。

🤖 Generated with [Claude Code](https://claude.ai/code)