### PR TITLE
.gitignoreからrepomix-output.xmlの除外設定を削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,5 +86,4 @@ temp/
 dev-emails/
 
 /src/generated/prisma
-repomix-output.xml
 .vercel


### PR DESCRIPTION
## 概要
- .gitignoreからrepomix-output.xmlの除外設定を削除しました

## 変更内容
- Repomixが生成するrepomix-output.xmlファイルをバージョン管理の対象に含めるように変更
- このファイルはリポジトリ全体の内容をまとめたファイルで、コード解析やレビューに使用されます

## テストプラン
- [x] .gitignoreファイルからrepomix-output.xmlの行が削除されていることを確認
- [x] git statusでrepomix-output.xmlがtrackされるようになることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)