### PR TITLE
プロジェクト作成時にガイドモーダルを表示する機能を追加

### DIFF
--- a/frontend/task-master-ui/app/globals.css
+++ b/frontend/task-master-ui/app/globals.css
@@ -149,12 +149,42 @@
 	}
 }
 
+@keyframes fadeIn {
+	from {
+		opacity: 0;
+		transform: scale(0.8);
+	}
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+
+@keyframes scaleIn {
+	from {
+		opacity: 0;
+		transform: scale(0);
+	}
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+
 .animate-fade-in {
 	animation: fade-in 0.3s ease-out;
 }
 
 .animate-slide-up {
 	animation: slide-up 0.3s ease-out;
+}
+
+.animate-fadeIn {
+	animation: fadeIn 0.3s ease-out forwards;
+}
+
+.animate-scaleIn {
+	animation: scaleIn 0.5s ease-out forwards;
 }
 
 /* Scrollbar styling */

--- a/frontend/task-master-ui/app/page.tsx
+++ b/frontend/task-master-ui/app/page.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Spinner } from '@/components/ui/spinner';
 import { ProjectItem } from '@/components/dashboard/ProjectItem';
+import { ProjectCreationGuideModal } from '@/components/project-creation-guide-modal';
 import { api, Project } from '@/lib/api';
 import { withAuth } from '@/lib/auth';
 
@@ -15,6 +16,7 @@ function DashboardPage() {
 	const router = useRouter();
 	const [projects, setProjects] = useState<Project[]>([]);
 	const [loading, setLoading] = useState(true);
+	const [showGuideModal, setShowGuideModal] = useState(false);
 
 	useEffect(() => {
 		loadProjects();
@@ -37,6 +39,15 @@ function DashboardPage() {
 		router.push(`/projects/${projectId}`);
 	};
 
+	const handleCreateProject = () => {
+		setShowGuideModal(true);
+	};
+
+	const handleContinueFromModal = () => {
+		setShowGuideModal(false);
+		router.push('/projects/new');
+	};
+
 	if (loading) {
 		return (
 			<div className="flex items-center justify-center min-h-[60vh]">
@@ -53,10 +64,8 @@ function DashboardPage() {
 						<h1 className="text-xl font-medium text-gray-900">
 							プロジェクト
 						</h1>
-						<Button asChild variant="ghost" size="sm">
-							<Link href="/projects/new">
-								<Plus className="h-4 w-4" />
-							</Link>
+						<Button variant="ghost" size="sm" onClick={handleCreateProject}>
+							<Plus className="h-4 w-4" />
 						</Button>
 					</div>
 				</div>
@@ -88,7 +97,7 @@ function DashboardPage() {
 						description="新規プロジェクトを作成して、タスク管理を始めましょう"
 						action={{
 							label: 'プロジェクトを作成',
-							onClick: () => router.push('/projects/new')
+							onClick: handleCreateProject
 						}}
 					/>
 				) : (
@@ -103,6 +112,12 @@ function DashboardPage() {
 					</div>
 				)}
 			</div>
+
+			<ProjectCreationGuideModal
+				open={showGuideModal}
+				onOpenChange={setShowGuideModal}
+				onContinue={handleContinueFromModal}
+			/>
 		</div>
 	);
 }

--- a/frontend/task-master-ui/components/project-creation-guide-modal.tsx
+++ b/frontend/task-master-ui/components/project-creation-guide-modal.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { 
+  FileText, 
+  Bot, 
+  Sparkles, 
+  CheckCircle2, 
+  ChevronLeft, 
+  ChevronRight,
+  MessageSquare,
+  Wand2,
+  Edit3,
+  ArrowRight
+} from 'lucide-react';
+
+interface ProjectCreationGuideModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onContinue: () => void;
+}
+
+const steps = [
+  {
+    id: 1,
+    icon: FileText,
+    title: 'PRDを入力',
+    description: 'プロジェクトの要件を記入',
+    visual: (
+      <div className="relative mx-auto w-48 h-48">
+        <div className="absolute inset-0 bg-primary/5 rounded-lg animate-pulse" />
+        <div className="absolute inset-2 bg-white rounded border-2 border-primary/20 p-4">
+          <div className="space-y-2">
+            <div className="h-2 bg-primary/20 rounded animate-pulse" />
+            <div className="h-2 bg-primary/20 rounded animate-pulse w-4/5" />
+            <div className="h-2 bg-primary/20 rounded animate-pulse w-3/5" />
+          </div>
+          <FileText className="absolute bottom-3 right-3 w-8 h-8 text-primary/40" />
+        </div>
+      </div>
+    )
+  },
+  {
+    id: 2,
+    icon: Bot,
+    title: 'AIと対話',
+    description: 'AIが詳細を確認',
+    visual: (
+      <div className="relative mx-auto w-48 h-48 flex items-center justify-center">
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="relative">
+            <Bot className="w-16 h-16 text-primary" />
+            <MessageSquare className="absolute -top-2 -right-2 w-6 h-6 text-primary animate-bounce" />
+          </div>
+        </div>
+        <div className="absolute bottom-0 left-0 right-0 flex justify-center gap-1">
+          <div className="w-2 h-2 bg-primary/40 rounded-full animate-pulse" />
+          <div className="w-2 h-2 bg-primary/40 rounded-full animate-pulse delay-100" />
+          <div className="w-2 h-2 bg-primary/40 rounded-full animate-pulse delay-200" />
+        </div>
+      </div>
+    )
+  },
+  {
+    id: 3,
+    icon: Sparkles,
+    title: 'タスク自動生成',
+    description: 'AIがタスクを分解',
+    visual: (
+      <div className="relative mx-auto w-48 h-48">
+        <div className="absolute inset-0 flex items-center justify-center">
+          <Wand2 className="w-12 h-12 text-primary animate-pulse" />
+        </div>
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="grid grid-cols-2 gap-2 mt-12">
+            <div className="w-16 h-8 bg-primary/10 rounded border border-primary/20 animate-fadeIn" />
+            <div className="w-16 h-8 bg-primary/10 rounded border border-primary/20 animate-fadeIn delay-100" />
+            <div className="w-16 h-8 bg-primary/10 rounded border border-primary/20 animate-fadeIn delay-200" />
+            <div className="w-16 h-8 bg-primary/10 rounded border border-primary/20 animate-fadeIn delay-300" />
+          </div>
+        </div>
+        <Sparkles className="absolute top-4 right-4 w-6 h-6 text-yellow-500 animate-spin" />
+        <Sparkles className="absolute top-8 left-6 w-4 h-4 text-yellow-500 animate-spin delay-200" />
+      </div>
+    )
+  },
+  {
+    id: 4,
+    icon: CheckCircle2,
+    title: '確認・編集',
+    description: 'タスクを調整して完成',
+    visual: (
+      <div className="relative mx-auto w-48 h-48 flex items-center justify-center">
+        <div className="relative">
+          <div className="w-32 h-32 rounded-full border-4 border-primary/20" />
+          <CheckCircle2 className="absolute inset-0 m-auto w-16 h-16 text-green-500 animate-scaleIn" />
+          <Edit3 className="absolute -bottom-2 -right-2 w-8 h-8 text-primary bg-white rounded-full p-1 shadow-lg" />
+        </div>
+      </div>
+    )
+  }
+];
+
+export function ProjectCreationGuideModal({
+  open,
+  onOpenChange,
+  onContinue,
+}: ProjectCreationGuideModalProps) {
+  const [currentStep, setCurrentStep] = useState(0);
+
+  const handleNext = () => {
+    if (currentStep < steps.length - 1) {
+      setCurrentStep(currentStep + 1);
+    } else {
+      onContinue();
+    }
+  };
+
+  const handlePrev = () => {
+    if (currentStep > 0) {
+      setCurrentStep(currentStep - 1);
+    }
+  };
+
+  const handleClose = () => {
+    setCurrentStep(0);
+    onOpenChange(false);
+  };
+
+  const step = steps[currentStep];
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <div className="text-center pt-6">
+          <div className="mb-6">
+            {step.visual}
+          </div>
+          
+          <h2 className="text-2xl font-semibold mb-2 flex items-center justify-center gap-2">
+            <step.icon className="w-6 h-6 text-primary" />
+            {step.title}
+          </h2>
+          
+          <p className="text-muted-foreground text-lg">
+            {step.description}
+          </p>
+          
+          <div className="flex justify-center gap-1 mt-8 mb-6">
+            {steps.map((_, index) => (
+              <div
+                key={index}
+                className={`h-2 w-2 rounded-full transition-all duration-300 ${
+                  index === currentStep 
+                    ? 'bg-primary w-8' 
+                    : index < currentStep 
+                    ? 'bg-primary/40' 
+                    : 'bg-muted'
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+        
+        <DialogFooter className="flex-row justify-between sm:justify-between">
+          <Button
+            variant="ghost"
+            onClick={handlePrev}
+            disabled={currentStep === 0}
+            className="gap-1"
+          >
+            <ChevronLeft className="w-4 h-4" />
+            戻る
+          </Button>
+          
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={handleClose}>
+              スキップ
+            </Button>
+            <Button onClick={handleNext} className="gap-1">
+              {currentStep === steps.length - 1 ? (
+                <>
+                  始める
+                  <ArrowRight className="w-4 h-4" />
+                </>
+              ) : (
+                <>
+                  次へ
+                  <ChevronRight className="w-4 h-4" />
+                </>
+              )}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/task-master-ui/components/project-creation-guide-modal.tsx
+++ b/frontend/task-master-ui/components/project-creation-guide-modal.tsx
@@ -5,6 +5,7 @@ import {
   Dialog,
   DialogContent,
   DialogFooter,
+  DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { 
@@ -138,6 +139,7 @@ export function ProjectCreationGuideModal({
   return (
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="max-w-md">
+        <DialogTitle className="sr-only">プロジェクト作成ガイド</DialogTitle>
         <div className="text-center pt-6">
           <div className="mb-6">
             {step.visual}


### PR DESCRIPTION
## Summary
- プロジェクト作成ボタンクリック時に、PRDからタスク自動生成の流れを説明するガイドモーダルを表示
- ステップ形式でビジュアル重視の説明を実装
- ユーザーが作成プロセスを理解しやすくすることで、機能の利用促進を図る

## Changes
### 新規コンポーネント
- `ProjectCreationGuideModal`: 4ステップのガイドモーダル
  - PRD入力
  - AIと対話
  - タスク自動生成
  - 確認・編集

### UI改善
- ビジュアルアイコンとアニメーション効果を追加
- ページ送り機能（戻る/次へ/スキップ）
- 進行状況インジケーター
- 文字数を最小限に抑えた直感的なデザイン

### 統合箇所
- ダッシュボードのヘッダー「+」ボタン
- プロジェクトがない時の「プロジェクトを作成」ボタン

## Test plan
- [ ] プロジェクト作成ボタンをクリックしてモーダルが表示されることを確認
- [ ] 各ステップ間の移動が正しく動作することを確認
- [ ] スキップボタンでモーダルが閉じることを確認
- [ ] 最後のステップで「始める」をクリックすると/projects/newへ遷移することを確認
- [ ] モーダルの「×」ボタンで閉じられることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)